### PR TITLE
fixed header

### DIFF
--- a/woocommerce-role-based-price.php
+++ b/woocommerce-role-based-price.php
@@ -21,7 +21,7 @@
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       woocommerce-role-based-price
- * Domain Path:       /languages
+ * Domain Path:       /languages/
  */
 
 if( ! defined('WPINC') ) {


### PR DESCRIPTION
there was a / missing to let the plugin have a valid header