### PR TITLE
Fix Export Locale Decimal Separator

### DIFF
--- a/plugins/wc-product-exporter/wc-product-exporter.php
+++ b/plugins/wc-product-exporter/wc-product-exporter.php
@@ -92,7 +92,7 @@ class wc_product_price_exporter {
                 foreach( $prices as $user => $price_types ) {
                     foreach( $price_types as $type => $price ) {
                         if( isset($row['wcrbp_' . $user . '_' . $type]) ) {
-                            $row['wcrbp_' . $user . '_' . $type] = $price;
+                            $row['wcrbp_' . $user . '_' . $type] = wc_format_localized_price($price);
                         }
                     }
                 }


### PR DESCRIPTION
If you have assigned "," as a decimal separator unit, the importer converts it to ".".

The exporter does not take this into account and exported it as it was in the database (with ".").

It is a simple change that calls the function "wc_format_localized_price" before adding the price.

Regards! :)