### PR TITLE
Set product_id

### DIFF
--- a/includes/class-product-pricing.php
+++ b/includes/class-product-pricing.php
@@ -170,6 +170,11 @@ class WooCommerce_Role_Based_Price_Product_Pricing {
                 $product_id = $product->get_id();
             }
 
+            /**
+             * $product_id needs to be set also if conditions above are not true.
+             */
+            $product_id = $product->get_id();
+
         } else {
 
             if( is_numeric($product) ) {


### PR DESCRIPTION
$product_id needs to be set, otherwise it causes problems with other plugins which are extending WC_Product class:
https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-product.php